### PR TITLE
added 单独设置一次请求需要的插件，

### DIFF
--- a/Sources/RxSwift/NetworkAPI+Rx.swift
+++ b/Sources/RxSwift/NetworkAPI+Rx.swift
@@ -6,15 +6,14 @@
 //  https://github.com/yangKJ/RxNetworks
 
 import Foundation
-@_exported import RxSwift
 import Moya
+@_exported import RxSwift
 
 public typealias APIObservableJSON = RxSwift.Observable<Any>
 
 /// 追加订阅网络方案
 /// Append the subscription network scheme.
-extension NetworkAPI {
-    
+public extension NetworkAPI {
     /// Network request.
     /// Protocol oriented network request, Indicator plugin are added by default
     /// Example:
@@ -30,14 +29,18 @@ extension NetworkAPI {
     ///
     /// - Parameter callbackQueue: Callback queue. If nil - queue from provider initializer will be used.
     /// - Returns: Observable sequence JSON object. May be thrown twice.
-    public func request(callbackQueue: DispatchQueue? = nil) -> APIObservableJSON {
-        var single: APIObservableJSON = APIObservableJSON.create { (observer) in
+    func request(
+        callbackQueue: DispatchQueue? = nil,
+        plugins: APIPlugins = []
+    ) -> APIObservableJSON {
+        var single = APIObservableJSON.create { observer in
             let token = HTTPRequest(success: { json in
                 observer.onNext(json)
                 observer.onCompleted()
             }, failure: { error in
                 observer.onError(error)
-            }, queue: callbackQueue)
+            }, queue: callbackQueue,
+            plugins: plugins)
             return Disposables.create {
                 token?.cancel()
             }


### PR DESCRIPTION
使用场景：缓存第一页的数据，只需要在初始化请求的时候设置一个 cache 插件，其他情况下不需要 cache
```swift
i.refresh
            .asDriver(onErrorJustReturn: ())
            .flatMapLatest({ [unowned self] _ in
                Api.firstpage
                    .request(
                        plugins: [NetworkCachePlugin(options: .cacheThenNetwork)]
                    )
                    .trackActivity(self.initing)
                    .trackError(self.initError)
                    .trackActivity(self.heading)
                    .decode(ApiResponse<MExecute>?.self)
                    .asDriver(onErrorJustReturn: nil)
            })
            .drive(onNext: { [weak self] response in
                guard let `self` = self else { return }
                guard let result = response?.data else {
                    return
                }
            })
            .disposed(by: rx.disposeBag)
```